### PR TITLE
convert empty voxels into solid voxels

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,10 @@ function convertToVoxels(hash) {
         if (current[1] > 0 && current[1] > bounds[1][1]) bounds[1][1] = current[1];
         if (current[2] < 0 && current[2] < bounds[0][2]) bounds[0][2] = current[2];
         if (current[2] > 0 && current[2] > bounds[1][2]) bounds[1][2] = current[2];
-        voxelData[current.slice(0, 3).join('|')] = current.slice(3)[0];
+        var idx = current.slice(0, 3).join('|');
+        var val = current.slice(3)[0];
+        if (val === 0) val = 1;
+        voxelData[idx] = val;
       }
     }
   }


### PR DESCRIPTION
there should be no way to encode air voxels in voxelbuilder creations, air is just the lack of data, not the presence of a 0. this fixes a bug with green voxels, which come decode as value 0 for some reason, causing this:

![screen shot 2013-08-14 at 2 55 03 pm](https://f.cloud.github.com/assets/39759/965512/3f1fcf2a-052c-11e3-8307-f41893786bd7.png)

after this fix:

![screen shot 2013-08-14 at 2 54 37 pm](https://f.cloud.github.com/assets/39759/965515/42ffef1c-052c-11e3-9a77-fc62dbe19203.png)
